### PR TITLE
Remove o php-di, valida o método __get e adiciona testes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
     "Central"
   ],
   "require": {
-    "php" : ">=5.6",
-    "php-di/php-di": "5.4.3"
+    "php" : ">=5.6"
   },
   "require-dev": {
     "phpunit/phpunit": "5.5.*"

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,8 +3,20 @@ namespace TotalVoice;
 
 use TotalVoice\Handler\Curl;
 use TotalVoice\Handler\Http;
-use DI\ContainerBuilder;
-use DI\NotFoundException;
+use TotalVoice\Api\Audio;
+use TotalVoice\Api\Bina;
+use TotalVoice\Api\Central;
+use TotalVoice\Api\Chamada;
+use TotalVoice\Api\Composto;
+use TotalVoice\Api\Conferencia;
+use TotalVoice\Api\Conta;
+use TotalVoice\Api\Did;
+use TotalVoice\Api\Fila;
+use TotalVoice\Api\Perfil;
+use TotalVoice\Api\Sms;
+use TotalVoice\Api\Status;
+use TotalVoice\Api\Tts;
+use TotalVoice\Api\Verificacao;
 
 class Client implements ClientInterface
 {
@@ -14,9 +26,24 @@ class Client implements ClientInterface
     const BASE_URI = 'https://api2.totalvoice.com.br';
 
     /**
-     * @var string
+     * @var array Items disponíveis para criação via __get
      */
-    const NAMESPACE_API = 'TotalVoice\\Api\\';
+    const API_ITEMS = [
+        'audio' => Audio::class,
+        'bina' => Bina::class,
+        'central' => Central::class,
+        'chamada' => Chamada::class,
+        'composto' => Composto::class,
+        'conferencia' => Conferencia::class,
+        'conta' => Conta::class,
+        'did' => Did::class,
+        'fila' => Fila::class,
+        'perfil' => Perfil::class,
+        'sms' => Sms::class,
+        'status' => Status::class,
+        'tts' => Tts::class,
+        'verificacao' => Verificacao::class,
+    ];
 
     /**
      * @var string
@@ -132,17 +159,12 @@ class Client implements ClientInterface
      * @return mixed
      * @throws ClientException
      */
-    public function __get($name) 
+    public function __get($name)
     {
-        try {
-            $builder = new ContainerBuilder();
-            $container = $builder->build();
-
-            $class = static::NAMESPACE_API . ucwords($name);
-            return $container->make($class, ['client' => $this]);
-
-        } catch(NotFoundException $e) {
-            throw new ClientException(sprintf('Não foi possível instanciar a classe: %s', $class));
+        if(!array_key_exists(strtolower($name), static::API_ITEMS)) {
+            throw new ClientException(sprintf('Não foi possível instanciar a classe: %s', $name));
         }
+        $class = static::API_ITEMS[$name];
+        return new $class($this);
     }
 }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -2,6 +2,23 @@
 namespace TotalVoice;
 
 use TotalVoice\Handler\Http;
+use TotalVoice\Api\Api;
+use TotalVoice\Api\ApiRelatorio;
+use TotalVoice\Api\ApiRelatorioChamadas;
+use TotalVoice\Api\Audio;
+use TotalVoice\Api\Bina;
+use TotalVoice\Api\Central;
+use TotalVoice\Api\Chamada;
+use TotalVoice\Api\Composto;
+use TotalVoice\Api\Conferencia;
+use TotalVoice\Api\Conta;
+use TotalVoice\Api\Did;
+use TotalVoice\Api\Fila;
+use TotalVoice\Api\Perfil;
+use TotalVoice\Api\Sms;
+use TotalVoice\Api\Status;
+use TotalVoice\Api\Tts;
+use TotalVoice\Api\Verificacao;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -44,5 +61,52 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $query = $this->client->query(['query' => 'string']);
         $this->assertEquals("?query=string", $query);
+    }
+
+    /**
+     * @test
+     */
+    public function apiInstancesTest()
+    {
+        $audio = $this->client->audio;
+        $bina = $this->client->bina;
+        $central = $this->client->central;
+        $chamada = $this->client->chamada;
+        $composto = $this->client->composto;
+        $conferencia = $this->client->conferencia;
+        $conta = $this->client->conta;
+        $did = $this->client->did;
+        $fila = $this->client->fila;
+        $perfil = $this->client->perfil;
+        $sms = $this->client->sms;
+        $status = $this->client->status;
+        $tts = $this->client->tts;
+        $verificacao = $this->client->verificacao;
+
+        $this->assertInstanceOf(Audio::class, $audio);
+        $this->assertInstanceOf(Bina::class, $bina);
+        $this->assertInstanceOf(Central::class, $central);
+        $this->assertInstanceOf(Chamada::class, $chamada);
+        $this->assertInstanceOf(Composto::class, $composto);
+        $this->assertInstanceOf(Conferencia::class, $conferencia);
+        $this->assertInstanceOf(Conta::class, $conta);
+        $this->assertInstanceOf(Did::class, $did);
+        $this->assertInstanceOf(Fila::class, $fila);
+        $this->assertInstanceOf(Perfil::class, $perfil);
+        $this->assertInstanceOf(Sms::class, $sms);
+        $this->assertInstanceOf(Status::class, $status);
+        $this->assertInstanceOf(Tts::class, $tts);
+        $this->assertInstanceOf(Verificacao::class, $verificacao);
+    }
+
+    /**
+     * @test
+     */
+    public function apiThrowClientException()
+    {
+        $name = 'invalidapiitem';
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage("Não foi possível instanciar a classe: $name");
+        $this->client->$name;
     }
 }


### PR DESCRIPTION
Olá.

Estou usando o totalvoice em um projeto com slim framework e tive problemas com a dependência do totalvoice com o [php-di](https://github.com/totalvoice/totalvoice-php/blob/master/src/Client.php#L138). 

Meu projeto também utiliza o php-di, mas em uma versão mais nova e o composer não permite que existam duas versões diferentes instaladas. Ao analisar o projeto de vocês, vi que o uso do php-di pode ser eliminado sem nenhum prejuízo aos usuários.

Fiz a remoção do php-di e adicionei a restrição do `__get` para um conjunto bem definido de classes da api. O modelo anterior permitia instanciar qualquer classe que estivesse em **src/Api**, no entanto, como existem classes abstratas nessa pasta, não fica imediatamente claro que classes podem realmente ser instanciadas desse modo.
