### PR TITLE
Typo na url do DID

### DIFF
--- a/src/Api/Did.php
+++ b/src/Api/Did.php
@@ -13,12 +13,12 @@ class Did extends ApiRelatorioChamadas
     /**
      * @var string
      */
-    const ROTA_DID_ESTOQUE = '/did/estoque';
+    const ROTA_DID_ESTOQUE = '/did/estoque/';
 
     /**
      * @var string
      */
-    const ROTA_DID_CHAMADA = '/did/chamada';
+    const ROTA_DID_CHAMADA = '/did/chamada/';
 
     /**
      * Lista todos os dids pertencentes


### PR DESCRIPTION
Atualmente a url está indo:
```https://api2.totalvoice.com.br/did/chamadaXXXX```
deveria ser:
```https://api2.totalvoice.com.br/did/chamada/XXXX```