### PR TITLE
fix(psr-4): correção do nome de classe com erro de digitação

### DIFF
--- a/test/Handler/ResponseTest.php
+++ b/test/Handler/ResponseTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace TotalVoice\Handler;
 
-class ResponselTest extends \PHPUnit_Framework_TestCase
+class ResponseTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Response


### PR DESCRIPTION
Correção do nome de classe do arquivo: `test/Handler/ResponseTest.php`

Conforme **warning** do próprio composer:

```
Deprecation Notice: Class TotalVoice\Handler\ResponselTest located in ./vendor/total-voice/php-client/test/Handler/ResponseTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in /usr/share/php/Composer/Autoload/ClassMapGenerator.php:201
```